### PR TITLE
Adding code logic for tagcloud-link attribute

### DIFF
--- a/tagcloud/tagcloud.js
+++ b/tagcloud/tagcloud.js
@@ -94,8 +94,18 @@
         // Size and colour the cloud tags
         [].forEach.call( cloud.querySelectorAll('span'), function(elem) {
             elem.style.fontSize = calcSize(elem) + '%';
-            elem.style.color = tagColor(elem, isBlackWhite);
             elem.classList.add('clouditem');
+            if( elem.hasAttribute('tagcloud-link') ) {
+                newelem = document.createElement('a');
+                newelem.innerHTML = elem.innerHTML;
+                newelem.style.color = tagColor(elem, isBlackWhite);
+                newelem.setAttribute('href', '/#/' + elem.getAttribute('tagcloud-link'));
+                elem.innerHTML = '';
+                elem.appendChild(newelem);
+            }
+            else {
+                elem.style.color = tagColor(elem, false);
+            }
         });
     });
 })();


### PR DESCRIPTION
Similarly to tagcloud-weight this change takes an attribute tagcloud-link and generates an a href element linking within the presentation.

For example `<span tagcloud-link="42">Twitter Bootstrap</span>` will generate a link to /#/42, which is the 42nd slide in the presentation.

Fixes #5 
